### PR TITLE
Simplify the use of custom codepoint regions

### DIFF
--- a/src/main/java/in/jord/jordinjemoji/EmojiManager.java
+++ b/src/main/java/in/jord/jordinjemoji/EmojiManager.java
@@ -22,8 +22,6 @@ import static in.jord.jordinjemoji.util.UnicodeUtil.codePointsToUnicode;
 
 public final class EmojiManager {
     private static final String BASE_DIRECTORY = "twemoji/assets/svg";
-    public static final int PRIVATE_USE_AREA_A_START = StandardUnassignedUnicodeRegion.SUPPLEMENTARY_PRIVATE_USE_AREA_A.getBaseCodePoint();
-    public static final int PRIVATE_USE_AREA_B_START = StandardUnassignedUnicodeRegion.SUPPLEMENTARY_PRIVATE_USE_AREA_B.getBaseCodePoint();
 
     private final int baseCodePoint;
     private final int emojiCount;

--- a/src/main/java/in/jord/jordinjemoji/EmojiManager.java
+++ b/src/main/java/in/jord/jordinjemoji/EmojiManager.java
@@ -3,6 +3,7 @@ package in.jord.jordinjemoji;
 import com.vdurmont.emoji.Emoji;
 import com.vdurmont.emoji.EmojiParser;
 import in.jord.jordinjemoji.rasterisation.EmojiRasteriser;
+import in.jord.jordinjemoji.util.StandardUnassignedUnicodeRegion;
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.Resource;
 import io.github.classgraph.ResourceList;
@@ -21,8 +22,8 @@ import static in.jord.jordinjemoji.util.UnicodeUtil.codePointsToUnicode;
 
 public final class EmojiManager {
     private static final String BASE_DIRECTORY = "twemoji/assets/svg";
-    public static final int PRIVATE_USE_AREA_A_START = 0xF0000;
-    public static final int PRIVATE_USE_AREA_B_START = 0x100000;
+    public static final int PRIVATE_USE_AREA_A_START = StandardUnassignedUnicodeRegion.SUPPLEMENTARY_PRIVATE_USE_AREA_A.getBaseCodePoint();
+    public static final int PRIVATE_USE_AREA_B_START = StandardUnassignedUnicodeRegion.SUPPLEMENTARY_PRIVATE_USE_AREA_B.getBaseCodePoint();
 
     private final int baseCodePoint;
     private final int emojiCount;
@@ -31,18 +32,6 @@ public final class EmojiManager {
     private final Map<String, String> unicodeToCodePoint;
     private final List<String> codePointToResource;
     private final EmojiRasteriser rasteriser = new EmojiRasteriser(this);
-
-    public EmojiManager() throws IOException {
-        this(name -> EmojiManager.class.getClassLoader().getResourceAsStream(BASE_DIRECTORY + "/" + name));
-    }
-
-    public EmojiManager(final Function<String, InputStream> resourceAsStream) throws IOException {
-        this.resourceAsStream = resourceAsStream;
-        this.unicodeToCodePoint = new HashMap<>();
-        this.codePointToResource = new ArrayList<>();
-        this.baseCodePoint = PRIVATE_USE_AREA_A_START;
-        this.emojiCount = this.scanForEmoji();
-    }
 
     public EmojiManager(final Function<String, InputStream> resourceAsStream,
                         final Map<String, String> unicodeToCodePoint,
@@ -56,6 +45,26 @@ public final class EmojiManager {
         this.codePointToResource = codePointToResource;
         this.baseCodePoint = baseCodePoint;
         this.emojiCount = codePointToResource.size();
+    }
+
+    public EmojiManager(final Function<String, InputStream> resourceAsStream, final int baseCodePoint) throws IOException {
+        this.resourceAsStream = resourceAsStream;
+        this.unicodeToCodePoint = new HashMap<>();
+        this.codePointToResource = new ArrayList<>();
+        this.baseCodePoint = baseCodePoint;
+        this.emojiCount = this.scanForEmoji();
+    }
+
+    public EmojiManager(final Function<String, InputStream> resourceAsStream, final StandardUnassignedUnicodeRegion region) throws IOException {
+        this(resourceAsStream, region.getBaseCodePoint());
+    }
+
+    public EmojiManager(final Function<String, InputStream> resourceAsStream) throws IOException {
+        this(resourceAsStream, StandardUnassignedUnicodeRegion.SUPPLEMENTARY_PRIVATE_USE_AREA_A);
+    }
+
+    public EmojiManager() throws IOException {
+        this(name -> EmojiManager.class.getClassLoader().getResourceAsStream(BASE_DIRECTORY + "/" + name));
     }
 
     public String convertEmojiToCodePoints(final String input) {

--- a/src/main/java/in/jord/jordinjemoji/util/StandardUnassignedUnicodeRegion.java
+++ b/src/main/java/in/jord/jordinjemoji/util/StandardUnassignedUnicodeRegion.java
@@ -1,0 +1,17 @@
+package in.jord.jordinjemoji.util;
+
+public enum StandardUnassignedUnicodeRegion {
+    PRIVATE_USE_AREA(0xE000),
+    SUPPLEMENTARY_PRIVATE_USE_AREA_A(0xF0000),
+    SUPPLEMENTARY_PRIVATE_USE_AREA_B(0x100000);
+
+    private final int baseCodePoint;
+
+    StandardUnassignedUnicodeRegion(int baseCodePoint) {
+        this.baseCodePoint = baseCodePoint;
+    }
+
+    public int getBaseCodePoint() {
+        return this.baseCodePoint;
+    }
+}


### PR DESCRIPTION
If an application is already using parts of the Private Use Areas, it can be cumbersome to use the full constructor just to pass in a baseCodePoint to the EmojiManager. This way, we can pass in either a standard region (via the new StandardUnassignedUnicodeRegion enum) or a completely custom integer.

By the way, is there any point in having the PRIVATE_USE_AREA_?_START constants? I didn't want to remove them since they're `public` in the code - that'd be an API-breaking change.

We should probably also bump the minor version if this gets approved. Waiting to hear from you!